### PR TITLE
Adding New Tag Classes

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/FordTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/FordTag.java
@@ -1,0 +1,30 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+
+/**
+ * OSM Ford Tag.
+ *
+ * @author sayas01
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/ford#values", osm = "https://wiki.openstreetmap.org/wiki/Key:ford")
+public enum FordTag
+{
+    YES,
+    STEPPING_STONES,
+    SEASONAL,
+    NO,
+    STREAM,
+    LEVEL_CROSSING,
+    BOAT;
+
+    @TagKey
+    public static final String KEY = "ford";
+
+    public static boolean isYes(final Taggable taggable)
+    {
+        return Validators.isOfType(taggable, FordTag.class, FordTag.YES);
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/SkiTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/SkiTag.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM Ski Tag.
+ *
+ * @author sayas01
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/ski#values", osm = "https://wiki.openstreetmap.org/wiki/Key:ski")
+public enum SkiTag
+{
+    NO,
+    YES,
+    DESIGNATED,
+    OFFICIAL,
+    PERMISSIVE,
+    CROSSING,
+    PRIVATE,
+    DOWNHILL,
+    CUSTOMERS,
+    NORDIC;
+
+    @TagKey
+    public static final String KEY = "ski";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/SnowmobileTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/SnowmobileTag.java
@@ -1,0 +1,22 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM Snowmobile Tag.
+ *
+ * @author sayas01
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/snowmobile#values", osm = "https://wiki.openstreetmap.org/wiki/Key:snowmobile")
+public enum SnowmobileTag
+{
+    NO,
+    DESIGNATED,
+    YES,
+    PERMISSIVE,
+    PRIVATE;
+
+    @TagKey
+    public static final String KEY = "snowmobile";
+}

--- a/src/main/java/org/openstreetmap/atlas/tags/WinterRoadTag.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/WinterRoadTag.java
@@ -1,0 +1,19 @@
+package org.openstreetmap.atlas.tags;
+
+import org.openstreetmap.atlas.tags.annotations.Tag;
+import org.openstreetmap.atlas.tags.annotations.TagKey;
+
+/**
+ * OSM Winter Tag.
+ *
+ * @author sayas01
+ */
+@Tag(taginfo = "https://taginfo.openstreetmap.org/keys/winter_road#values", osm = "https://wiki.openstreetmap.org/wiki/Key:winter_road")
+public enum WinterRoadTag
+{
+    YES,
+    NO;
+
+    @TagKey
+    public static final String KEY = "winter_road";
+}


### PR DESCRIPTION
### Description:

This PR adds the following four valid tags to Atlas:
1. [Ford Tag.](https://wiki.openstreetmap.org/wiki/Key:ford) All tag values that have count greater than .05% are added.
2. [Winter Road Tag.](https://wiki.openstreetmap.org/wiki/Key:winter_road)
3. [Snowmobile Tag.](https://wiki.openstreetmap.org/wiki/Key:snowmobile)
4. [Ski Tag.](https://wiki.openstreetmap.org/wiki/Key:ski)

### Potential Impact:

No potential impact except that the new tags can be used.

### Unit Test Approach:

NA

### Test Results:

NA

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
