### PR TITLE
Add Methods to Access TaggableFilter of ComplexAreaOfInterest

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/aoi/ComplexAreaOfInterest.java
+++ b/src/main/java/org/openstreetmap/atlas/geography/atlas/items/complex/aoi/ComplexAreaOfInterest.java
@@ -139,6 +139,25 @@ public final class ComplexAreaOfInterest extends ComplexEntity
         }
     }
 
+    /**
+     * Collect the list of {@link TaggableFilter} from the default list, the object passes.
+     *
+     * @return a list of {@link TaggableFilter}s the object passes
+     */
+    public List<TaggableFilter> getTaggableFiltersOfObject()
+    {
+        return defaultTaggableFilter.stream().filter(taggableFilter -> taggableFilter.test(this))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @return the default list of {@link TaggableFilter}
+     */
+    public static List<TaggableFilter> getDefaultTaggableFilter()
+    {
+        return defaultTaggableFilter;
+    }
+
     @Override
     public String toString()
     {

--- a/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/aoi/ComplexAreaOfInterestFinderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/geography/atlas/items/complex/aoi/ComplexAreaOfInterestFinderTest.java
@@ -57,4 +57,15 @@ public class ComplexAreaOfInterestFinderTest
                 TaggableFilter.forDefinition("landuse->VINEYARD|amenity->SCHOOL"));
         Assert.assertEquals(3, StreamSupport.stream(complexAOIs.spliterator(), false).count());
     }
+
+    @Test
+    public void testTaggableFilterOfObject()
+    {
+        final Atlas atlas = this.rule.getAoiAreaAtlas();
+        final ComplexAreaOfInterestFinder aoiRelationFinder = new ComplexAreaOfInterestFinder();
+        final Iterable<ComplexAreaOfInterest> complexAOIAreas = aoiRelationFinder.find(atlas);
+        Assert.assertEquals(1,
+                complexAOIAreas.iterator().next().getTaggableFiltersOfObject().size());
+        Assert.assertEquals(15, ComplexAreaOfInterest.getDefaultTaggableFilter().size());
+    }
 }


### PR DESCRIPTION
### Description:

This PR adds two new methods : 

1. `getTaggableFiltersOfObject` to get the list of TaggableFilters (from the default list) that the ComplexEntity passes. `getTaggableFiltersOfObject` will be useful to retrieve ComplexAreasOfInterests from an Atlas that have the same filters as that of the given ComplexEntity.

2. `getDefaultTaggableFilter` to get the default list of TaggableFilters based on which the ComplexAreaOfInterest was built.

### Potential Impact:

None except addition of two handy methods.

### Unit Test Approach:

Added a unit test to test the methods.

### Test Results:

All tests passing.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
